### PR TITLE
Remove SameObject attribute from skipRendering

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1841,7 +1841,7 @@ interface XRInputSource {
   [SameObject] readonly attribute XRSpace targetRaySpace;
   [SameObject] readonly attribute XRSpace? gripSpace;
   [SameObject] readonly attribute FrozenArray&lt;DOMString&gt; profiles;
-  [SameObject] readonly attribute boolean skipRendering;
+  readonly attribute boolean skipRendering;
 };
 </pre>
 


### PR DESCRIPTION
Per [WebIDL spec](https://webidl.spec.whatwg.org/#SameObject), 

> The [SameObject] extended attribute must not be used on anything other than a read only attribute whose type is an interface type or object.

`skipRendering` is a boolean, so it isn't eligible. Encountered while updating Servo and getting an error during codegen